### PR TITLE
Skip header when parsing CSV

### DIFF
--- a/lib/airports.ex
+++ b/lib/airports.ex
@@ -7,7 +7,7 @@ defmodule Airports do
   @airports [__DIR__, "../priv", "airports.csv"]
             |> Path.join()
             |> File.stream!([], :line)
-            |> AirportsParser.parse_stream(skip_headers: false)
+            |> AirportsParser.parse_stream(skip_headers: true)
             |> Stream.map(fn line ->
               [
                 _,

--- a/test/airports_test.exs
+++ b/test/airports_test.exs
@@ -8,6 +8,8 @@ defmodule AirportsTest do
       |> File.stream!([], :line)
       |> Enum.to_list()
       |> Enum.count()
+      # minus header
+      |> Kernel.-(1)
 
     assert Enum.count(Airports.all()) == lines_count_from_source
   end


### PR DESCRIPTION
Fix `Airports.all()` including header on the list